### PR TITLE
Update DNSDigCheckValidation.php

### DIFF
--- a/EmailValidator/Validation/DNSDigCheckValidation.php
+++ b/EmailValidator/Validation/DNSDigCheckValidation.php
@@ -9,8 +9,11 @@ namespace Egulias\EmailValidator\Validation;
 use JeronimoFagundes\PhpDig\Dig;
 use JeronimoFagundes\PhpDig\DigConfig;
 
+use Egulias\EmailValidator\Exception\InvalidEmail;
+use Egulias\EmailValidator\Warning\NoDNSMXRecord;
+use Egulias\EmailValidator\Exception\NoDNSRecord;
 
-class DNSDigCheckValidation extends DNSCkeckValidation
+class DNSDigCheckValidation extends DNSCheckValidation
 {
     /**
      * @var string


### PR DESCRIPTION
Fix extends  DNSCkeckValidation Wrong > DNSCheckValidation Wright
Added this because throws error without
use Egulias\EmailValidator\Exception\InvalidEmail;
use Egulias\EmailValidator\Warning\NoDNSMXRecord;
use Egulias\EmailValidator\Exception\NoDNSRecord;